### PR TITLE
Fix: Message for notifing the allowed chars in username

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/users/add.php
+++ b/web/concrete/controllers/single_page/dashboard/users/add.php
@@ -64,7 +64,7 @@ class Add extends DashboardPageController {
 
 		if (strlen($username) >= Config::get('concrete.user.username.minimum') && !$valc->username($username)) {
 			if(Config::get('concrete.user.username.allow_spaces')) {
-				$this->error->add(t('A username may only contain letters, numbers, spaces, dots (not at the beginning/end), underscores (not at the beginning/end).'));
+				$this->error->add(t('A username may only contain letters, numbers, spaces (not at the beginning/end), dots (not at the beginning/end), underscores (not at the beginning/end).'));
 			} else {
 				$this->error->add(t('A username may only contain letters numbers, dots (not at the beginning/end), underscores (not at the beginning/end).'));
 			}


### PR DESCRIPTION
space only allowed in the middle of username